### PR TITLE
Fix deprecated warnings

### DIFF
--- a/README.mdown
+++ b/README.mdown
@@ -25,15 +25,15 @@ Here's an example of our services.yml, you don't really need to change this sinc
 ```yaml
 services:
   phy_cache.client:
-    class: %phy_cache.class%
-    arguments: [ %phy_cache.settings% ]
+    class: '%phy_cache.class%'
+    arguments: [ '%phy_cache.settings%' ]
   phy_cache:
     class: PHY\CacheBundle\Cache
     arguments: [ '@phy_cache.client' ]
     calls:
-      - [ setExpiration, [ %phy_cache.expiration% ] ]
-      - [ setCompression, [ %phy_cache.compression% ] ]
-      - [ setPrefix, [ %phy_cache.prefix% ] ]
+      - [ setExpiration, [ '%phy_cache.expiration%' ] ]
+      - [ setCompression, [ '%phy_cache.compression%' ] ]
+      - [ setPrefix, [ '%phy_cache.prefix%' ] ]
 ```
 
 Here's how you'd setup some common caches in your parameters.yml

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -1,11 +1,11 @@
 services:
   phy_cache.client:
-    class: %phy_cache.class%
-    arguments: [ %phy_cache.settings% ]
+    class: '%phy_cache.class%'
+    arguments: [ '%phy_cache.settings%' ]
   phy_cache:
     class: PHY\CacheBundle\Cache
     arguments: [ '@phy_cache.client' ]
     calls:
-      - [ setExpiration, [ %phy_cache.expiration% ] ]
-      - [ setCompression, [ %phy_cache.compression% ] ]
-      - [ setPrefix, [ %phy_cache.prefix% ] ]
+      - [ setExpiration, [ '%phy_cache.expiration%' ] ]
+      - [ setCompression, [ '%phy_cache.compression%' ] ]
+      - [ setPrefix, [ '%phy_cache.prefix%' ] ]


### PR DESCRIPTION
Fix following warnings :

- Not quoting the scalar "%phy_cache.class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0. Show trace
- Not quoting the scalar "%phy_cache.settings% " starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0. Show trace
- Not quoting the scalar "%phy_cache.expiration% " starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0. Show trace
- Not quoting the scalar "%phy_cache.compression% " starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0. Show trace
- Not quoting the scalar "%phy_cache.prefix% " starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0. Show trace